### PR TITLE
Added a Particle and Vec class

### DIFF
--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -1,0 +1,49 @@
+#ifndef __PARTICLE_HPP__
+#define __PARTICLE_HPP__
+
+#include "Vec.hpp"
+
+template<typename T, size_t N>
+class Particle {
+    public:
+        Particle() {
+            m_pos = Vec<T, N>();
+            m_velo = Vec<T, N>();
+            m_accel = Vec<T, N>();
+            m_mass = 1.f;
+            m_restitution = 1.f;
+        }
+
+        Particle(const Vec<T, N>& pos) : m_pos(pos) {
+            m_velo = Vec<T, N>();
+            m_accel = Vec<T, N>();
+            m_mass = 1.f;
+            m_restitution = 1.f;
+        }
+
+        // Step forward in time
+        void step(float dt) {
+            // TODO: We need to use something better than the Euler method in
+            // the future. Perhaps Verlet?
+
+            // Simple Euler integration
+            m_velo += m_accel * dt;
+            m_pos += 0.5 * m_velo * dt;
+
+            // Reset the acceleration to 0
+            m_accel = Vec<T, N>();
+        }
+
+    private:
+        Vec<T, N> m_pos;
+        Vec<T, N> m_velo;
+        Vec<T, N> m_accel;
+        T m_mass;
+        T m_restitution;
+};
+
+typedef Particle<float, 2> Particle2f;
+typedef Particle<float, 3> Particle3f;
+
+#endif /* __PARTICLE_HP__ */
+

--- a/src/Particle.hpp
+++ b/src/Particle.hpp
@@ -3,6 +3,9 @@
 
 #include "Vec.hpp"
 
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
 template<typename T, size_t N>
 class Particle {
     public:
@@ -28,7 +31,7 @@ class Particle {
 
             // Simple Euler integration
             m_velo += m_accel * dt;
-            m_pos += 0.5 * m_velo * dt;
+            m_pos += m_velo * 0.5f * dt;
 
             // Reset the acceleration to 0
             m_accel = Vec<T, N>();
@@ -44,6 +47,18 @@ class Particle {
 
 typedef Particle<float, 2> Particle2f;
 typedef Particle<float, 3> Particle3f;
+
+void py_init_particle(py::module& m) {
+    py::class_<Particle2f>(m, "Particle2f")
+        .def(py::init<>())
+        .def(py::init<const Vec2f&>())
+        .def("step", &Particle2f::step);
+
+    py::class_<Particle3f>(m, "Particle3f")
+        .def(py::init<>())
+        .def(py::init<const Vec3f&>())
+        .def("step", &Particle3f::step);
+}
 
 #endif /* __PARTICLE_HP__ */
 

--- a/src/Vec.hpp
+++ b/src/Vec.hpp
@@ -1,0 +1,69 @@
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+template <typename T, size_t N>
+class Vec {
+    public:
+        // 0-initialized constructor
+        Vec() {
+            m_data = {};
+        }
+
+        // FIXME: We are assuming N >= 1
+        // Base case for variadic constructor
+        Vec(T x) {
+            _construct(0, x);
+        }
+
+        // General case for variadic constructor
+        template<typename... Args>
+        Vec(T x, Args... args) {
+            _construct(0, x, args...);
+        }
+
+        // This clever template guarding of using n == N used in get_*() comes
+        // from:
+        // https://stackoverflow.com/a/39154242/6026013
+
+        // Return the x component if N >= 1
+        template <size_t n = N>
+        typename std::enable_if<n >= 1 && n == N, T>::type get_x() {
+            return m_data[0];
+        }
+
+        // Return the y component if N >= 2
+        template <size_t n = N>
+        typename std::enable_if<n >= 2 && n == N, T>::type get_y() {
+            return m_data[1];
+        }
+
+        // Return the z component if N >= 3
+        template <size_t n = N>
+        typename std::enable_if<n >= 3 && n == N, T>::type get_z() {
+            return m_data[2];
+        }
+
+        // Return the w component if N >= 4
+        template <size_t n = N>
+        typename std::enable_if<n >= 4 && n == N, T>::type get_w() {
+            return m_data[3];
+        }
+
+    private:
+        void _construct(const size_t i, T x) {
+            m_data[i] = x;
+        }
+
+        template<typename... Args>
+        void _construct(const size_t i, T x, Args... args) {
+            m_data[i] = x;
+            _construct(i+1, args...);
+        }
+
+        std::array<T, N> m_data;
+};
+
+typedef Vec<float, 2> Vec2f;
+typedef Vec<float, 3> Vec3f;
+

--- a/src/Vec.hpp
+++ b/src/Vec.hpp
@@ -5,6 +5,11 @@
 #include <cstddef>
 #include <type_traits>
 
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
 template <typename T, size_t N>
 class Vec {
     public:
@@ -14,7 +19,7 @@ class Vec {
         }
 
         // Initialize from an array
-        Vec(const std::array<T, N>&& data) {
+        Vec(const std::array<T, N>& data) {
             m_data = data;
         }
 
@@ -68,7 +73,7 @@ class Vec {
         Vec<T, N> operator*(const T rhs) {
             std::array<T, N> new_data = m_data;
             for (auto&& elem : new_data) {
-                new_data *= rhs;
+                elem *= rhs;
             }
             return Vec<T, N>(new_data);
         }
@@ -94,17 +99,18 @@ class Vec {
         std::array<T, N> m_data;
 };
 
-template<typename T, size_t N>
-Vec<T, N> operator*(const T lhs, const Vec<T, N>& rhs) {
-    std::array<T, N> new_data = rhs.m_data;
-    for (auto&& elem : new_data) {
-        new_data *= lhs;
-    }
-    return Vec<T, N>(new_data);
-}
-
 typedef Vec<float, 2> Vec2f;
 typedef Vec<float, 3> Vec3f;
+
+void py_init_vec(py::module& m) {
+    py::class_<Vec2f>(m, "Vec2f")
+        .def(py::init<>())
+        .def(py::init<const std::array<float, 2>&&>());
+
+    py::class_<Vec3f>(m, "Vec3f")
+        .def(py::init<>())
+        .def(py::init<const std::array<float, 3>&&>());
+}
 
 #endif /* __VEC_HPP__ */
 

--- a/src/Vec.hpp
+++ b/src/Vec.hpp
@@ -1,3 +1,6 @@
+#ifndef __VEC_HPP__
+#define __VEC_HPP__
+
 #include <array>
 #include <cstddef>
 #include <type_traits>
@@ -8,6 +11,11 @@ class Vec {
         // 0-initialized constructor
         Vec() {
             m_data = {};
+        }
+
+        // Initialize from an array
+        Vec(const std::array<T, N>&& data) {
+            m_data = data;
         }
 
         // FIXME: We are assuming N >= 1
@@ -28,26 +36,48 @@ class Vec {
 
         // Return the x component if N >= 1
         template <size_t n = N>
-        typename std::enable_if<n >= 1 && n == N, T>::type get_x() {
+        typename std::enable_if<n >= 1 && n == N, T>::type get_x() const {
             return m_data[0];
         }
 
         // Return the y component if N >= 2
         template <size_t n = N>
-        typename std::enable_if<n >= 2 && n == N, T>::type get_y() {
+        typename std::enable_if<n >= 2 && n == N, T>::type get_y() const {
             return m_data[1];
         }
 
         // Return the z component if N >= 3
         template <size_t n = N>
-        typename std::enable_if<n >= 3 && n == N, T>::type get_z() {
+        typename std::enable_if<n >= 3 && n == N, T>::type get_z() const {
             return m_data[2];
         }
 
         // Return the w component if N >= 4
         template <size_t n = N>
-        typename std::enable_if<n >= 4 && n == N, T>::type get_w() {
+        typename std::enable_if<n >= 4 && n == N, T>::type get_w() const {
             return m_data[3];
+        }
+
+        Vec<T, N>& operator+=(const Vec<T, N>& rhs) {
+            for (size_t i = 0; i < N; ++i) {
+                m_data[i] += rhs.m_data[i];
+            }
+            return *this;
+        }
+
+        Vec<T, N> operator*(const T rhs) {
+            std::array<T, N> new_data = m_data;
+            for (auto&& elem : new_data) {
+                new_data *= rhs;
+            }
+            return Vec<T, N>(new_data);
+        }
+
+        Vec<T, N>& operator*=(const T rhs) {
+            for (auto&& elem : m_data) {
+                elem *= rhs;
+            }
+            return *this;
         }
 
     private:
@@ -64,6 +94,17 @@ class Vec {
         std::array<T, N> m_data;
 };
 
+template<typename T, size_t N>
+Vec<T, N> operator*(const T lhs, const Vec<T, N>& rhs) {
+    std::array<T, N> new_data = rhs.m_data;
+    for (auto&& elem : new_data) {
+        new_data *= lhs;
+    }
+    return Vec<T, N>(new_data);
+}
+
 typedef Vec<float, 2> Vec2f;
 typedef Vec<float, 3> Vec3f;
+
+#endif /* __VEC_HPP__ */
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
 import simulator
 
-print(simulator.add(1, 2))
+v = simulator.Vec2f([1.0, 2.0])
+p = simulator.Particle2f(v)
+p.step(0.001)

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -1,13 +1,13 @@
+#include "Particle.hpp"
+#include "Vec.hpp"
+
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
-int add(int i, int j) {
-    return i + j;
-}
-
 PYBIND11_MODULE(simulator, m) {
-    m.doc() = "pybind11 example plugin"; // optional module docstring
+    m.doc() = "A simulator module";
 
-    m.def("add", &add, "A function which adds two numbers");
+    py_init_vec(m);
+    py_init_particle(m);
 }


### PR DESCRIPTION
I added a Particle and Vec class so we can start building the particle simulator. They are very simple right now, but we should be able to extend them quickly. They are accessible through python (I have an example in `src/main.py`).

The Vec class is pretty cool in my opinion becuase it exposes the functions `Vec::get_x()`, `Vec::get_y()`, `Vec::get_z()`, and `Vec::get_w()` only if the Vector is of the right dimension (which is determined at "compile-time" (not really compile-time since this is run in a Python interpreter, but you get the point)).