### PR TITLE
New Vec class, Velocity Verlet, and removed particle-particle interaction.

### DIFF
--- a/src/Simulator.hpp
+++ b/src/Simulator.hpp
@@ -1,6 +1,7 @@
 #ifndef __SIMULATOR_HPP__
 #define __SIMULATOR_HPP__
 
+#include <cmath>
 #include <random>
 #include <vector>
 #include <iostream>
@@ -8,8 +9,10 @@
 #include "Particle.hpp"
 #include "Wall.hpp"
 
+// TODO: Move these static functions to a utility namespace or something?
+
 static bool circle_circle_intersection(const float ra, const float x0a, const float y0a, const float rb, const float x0b, const float y0b) {
-    // Find the distance between the two centers
+    // Find the distance between the two centres
     const float d2 = (x0b - x0a) * (x0b - x0a) + (y0b - y0a) * (y0b - y0a);
 
     // We have an intersection if the distance is less than the sum of the radii
@@ -17,77 +20,95 @@ static bool circle_circle_intersection(const float ra, const float x0a, const fl
     return d2 <= (ra + rb) * (ra + rb);
 }
 
-static bool circle_line_intersection(const float r, const float x0, const float y0, const Vec2f A, const Vec2f B) {
-    // Algorithm from:
-    // https://mathworld.wolfram.com/Circle-LineIntersection.html
+static bool circle_line_intersection(const float r, const Vec center, const Vec A, const Vec B) {
+    Vec D = B - A;
+    Vec F = A - center;
 
-    // First, we adjust the circle and the points A and B such that the circle
-    // is at the origin
-    const Vec2f center = Vec2f(x0, y0);
-    const Vec2f A_prime = A - center;
-    const Vec2f B_prime = B - center;
+    float a = D.norm_sqr();
+    float b = 2.f * F.dot(D);
+    float c = F.norm_sqr() - r * r;
 
-    // Calculate D and d_r^2
-    const float D = (A_prime.get_x() + B_prime.get_y() - B_prime.get_x() * A_prime.get_y());
-    const float dr2 = (B_prime.get_x() - A_prime.get_x()) * (B_prime.get_x() - A_prime.get_x()) + (B_prime.get_y() - A_prime.get_y()) * (B_prime.get_y() - A_prime.get_y());
+    float delta2 = b * b  - 4.f * a * c;
 
-    return r*r * dr2 - D*D >= 0.f;
+    if (delta2 < 0.f) return false;
+
+    // TODO: We can get rid of this square root easily
+    float delta = std::sqrt(delta2);
+    float t1 = (-b - delta)/(2.f * a);
+    float t2 = (-b + delta)/(2.f * a);
+
+    return (t1 >= 0.f && t1 <= 1.f) || (t2 >= 0.f && t2 <= 1.f);
+}
+
+static Vec lennard_jones(const Vec A, const Vec B) {
+    const float r2 = (B - A).norm_sqr();
+
+    if (r2 < 0.1) return Vec(100000.f, 100000.f);
+
+    if (r2 < 6.25f) { // equivalent to r < 2.5 (V(x > 2.5) ≈ 0)
+        // TODO: Use the generalized form of the fast inverse square root
+        // described here: http://h14s.p5r.org/2012/09/0x5f3759df.html
+        // This can be used as style points because its a really neat algorithm
+        const float r6_inv = 1.f/(r2 * r2 * r2);
+
+        const float f_mag = -48.f * (r6_inv * r6_inv - 0.5f * r6_inv);
+        return (B - A).normalized() * f_mag;
+    }
+    return Vec(0.f, 0.f);
 }
 
 class Simulator {
     public:
         Simulator() {
-            m_particles = std::vector<Particle2f>();
+            m_particles = std::vector<Particle>();
             m_walls = std::vector<Wall>();
         }
 
-        Simulator(const size_t num_particles) {
+        Simulator(const size_t num_particles, std::vector<Wall>& walls) {
             std::default_random_engine generator; // TODO: Seed the generator perhaps?
             std::uniform_real_distribution<float> distribution(-1.f, 1.f);
 
             for (size_t i = 0; i < num_particles; ++i) {
-                Particle2f p(Vec2f(distribution(generator), distribution(generator)));
-                p.set_velo(Vec2f(distribution(generator) * 7.f, distribution(generator)) * 7.f);
+                Particle p(Vec(distribution(generator), distribution(generator)), Vec(distribution(generator), distribution(generator)) * 15.f);
                 m_particles.push_back(p);
             }
-            m_walls = std::vector<Wall>();
+            m_walls = walls;
         }
 
         void step(const float dt) {
-            // Collisions
             for (size_t i = 0; i < m_particles.size(); ++i) {
-                Particle2f p1 = m_particles[i];
-                for (size_t j = i+1; j < m_particles.size(); ++j) {
-                    Particle2f p2 = m_particles[j];
+                const Particle p1 = m_particles[i];
 
-                    // Particles bounce off of each other
-                    if (circle_circle_intersection(p1.get_radius(), p1.get_pos().get_x(), p1.get_pos().get_y(), p2.get_radius(), p2.get_pos().get_x(), p2.get_pos().get_y())) {
-                        const Vec2f x1 = p1.get_pos();
-                        Vec2f v1 = p1.get_velo();
-                        const float m1 = p1.get_mass();
-                        const Vec2f x2 = p2.get_pos();
-                        Vec2f v2 = p2.get_velo();
-                        const float m2 = p2.get_mass();
+                // Particles bounce off walls
+                for (auto wall : m_walls) {
+                    std::vector<Vec> verts = wall.get_vertices();
+                    for (size_t j = 0; j < verts.size() - 1; ++j) {
+                        Vec vert1 = verts[j];
+                        Vec vert2 = verts[j+1];
 
-                        // Ref: https://www.wikiwand.com/en/Elastic_collision
-                        v1 -= (x1 - x2) * (2*m2/(m1 + m2) * (v1 - v2).dot(x1 - x2) / (x1 - x2).norm_sqr());
-                        v2 -= (x2 - x1) * (2*m1/(m2 + m1) * (v2 - v1).dot(x2 - x1) / (x2 - x1).norm_sqr());
-
-                        m_particles[i].set_velo(v1);
-                        m_particles[j].set_velo(v2);
-
-                        std::cout << "Particle " << i << " and " << j << " bounced off each other\n";
+                        if (circle_line_intersection(p1.get_radius(), p1.get_pos(), vert1, vert2)) {
+                            Vec velo = p1.get_velo();
+                            Vec normal = Vec(-(vert2 - vert1).y, (vert2-vert1).x).normalized();
+                            velo -= normal * 2.f * velo.dot(normal);
+                            m_particles[i].set_velo(velo);
+                        }
                     }
-
-                    // Particles bounce off walls
-                    // TODO:
                 }
+
+                // QUESTION: Particles actually shouldn't bounce off each other in an ideal gas, so we can assume ideal gas for performance
+                // Particles bounce off of each other
+                // for (size_t j = i+1; j < m_particles.size(); ++j) {
+                    // const Particle p2 = m_particles[j];
+
+                    // Forces from neighbouring particles
+                    // Vec force = lennard_jones(p1.get_pos(), p2.get_pos());
+                    // m_particles[i].impulse(force);
+                    // m_particles[j].impulse(force * -1.f);
+
+                    // TODO: Add forces from external fields
+                // }
             }
 
-            // Add forces from external fields (we should create a Particle::impulse()
-            // function to use for this)
-            // TODO
-            
             // Step the particles in time (we don't move the walls because we
             // assume they do not deform)
             for (size_t i = 0; i < m_particles.size(); ++i) {
@@ -98,13 +119,13 @@ class Simulator {
         py::memoryview get_particle_positions() {
             float* positions = new float[m_particles.size() * 2];
             for (size_t i = 0; i < m_particles.size(); ++i) {
-                positions[2*i] = m_particles[i].get_pos().get_x();
-                positions[2*i + 1] = m_particles[i].get_pos().get_y();
+                positions[2*i] = m_particles[i].get_pos().x;
+                positions[2*i + 1] = m_particles[i].get_pos().y;
             }
             m_allocations.push_back(positions);
             return py::memoryview::from_buffer(
                     positions,
-                    {30, 2}, // rows, cols TODO: replace 10 with m_particles.size()
+                    {30, 2}, // rows, cols TODO: replace 30 with m_particles.size()
                     {2 * sizeof(float), sizeof(float)});
         }
 
@@ -116,7 +137,7 @@ class Simulator {
         }
 
     private:
-        std::vector<Particle2f> m_particles;
+        std::vector<Particle> m_particles;
         std::vector<Wall> m_walls;
         std::vector<float*> m_allocations;
 };
@@ -124,7 +145,7 @@ class Simulator {
 void py_init_simulator(py::module& m) {
     py::class_<Simulator>(m, "Simulator")
         .def(py::init<>())
-        .def(py::init<const size_t>())
+        .def(py::init<const size_t, std::vector<Wall>&>())
         .def("step", &Simulator::step)
         .def("get_particle_positions", &Simulator::get_particle_positions)
         .def("free_allocation", &Simulator::free_allocation);

--- a/src/Vec.hpp
+++ b/src/Vec.hpp
@@ -2,6 +2,7 @@
 #define __VEC_HPP__
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <type_traits>
 
@@ -10,137 +11,71 @@
 
 namespace py = pybind11;
 
-template <typename T, size_t N>
-class Vec {
-    public:
+struct Vec {
         // 0-initialized constructor
         Vec() {
-            m_data = {};
+            x = 0.f;
+            y = 0.f;
         }
 
-        // Initialize from an array
-        Vec(const std::array<T, N>& data) {
-            m_data = data;
+        Vec(float x, float y) :
+            x(x),
+            y(y) {}
+
+        Vec operator-(const Vec&rhs) const {
+            return Vec(x - rhs.x, y - rhs.y);
         }
 
-        // FIXME: We are assuming N >= 1
-        // Base case for variadic constructor
-        Vec(T x) {
-            _construct(0, x);
-        }
-
-        // General case for variadic constructor
-        template<typename... Args>
-        Vec(T x, Args... args) {
-            _construct(0, x, args...);
-        }
-
-        // This clever template guarding of using n == N used in get_*() comes
-        // from:
-        // https://stackoverflow.com/a/39154242/6026013
-
-        // Return the x component if N >= 1
-        template <size_t n = N>
-        typename std::enable_if<n >= 1 && n == N, T>::type get_x() const {
-            return m_data[0];
-        }
-
-        // Return the y component if N >= 2
-        template <size_t n = N>
-        typename std::enable_if<n >= 2 && n == N, T>::type get_y() const {
-            return m_data[1];
-        }
-
-        // Return the z component if N >= 3
-        template <size_t n = N>
-        typename std::enable_if<n >= 3 && n == N, T>::type get_z() const {
-            return m_data[2];
-        }
-
-        // Return the w component if N >= 4
-        template <size_t n = N>
-        typename std::enable_if<n >= 4 && n == N, T>::type get_w() const {
-            return m_data[3];
-        }
-
-        Vec<T, N> operator-(const Vec<T, N>&rhs) const {
-            std::array<T, N> new_data = m_data;
-            for (size_t i = 0; i < N; ++i) {
-                new_data[i] -= rhs.m_data[i];
-            }
-            return Vec<T, N>(new_data);
-        }
-
-        Vec<T, N>& operator-=(const Vec<T, N>& rhs) {
-            for (size_t i = 0; i < N; ++i) {
-                m_data[i] -= rhs.m_data[i];
-            }
+        Vec& operator-=(const Vec& rhs) {
+            x -= rhs.x;
+            y -= rhs.y;
             return *this;
         }
 
-        Vec<T, N>& operator+=(const Vec<T, N>& rhs) {
-            for (size_t i = 0; i < N; ++i) {
-                m_data[i] += rhs.m_data[i];
-            }
+        Vec operator+(const Vec& rhs) const {
+            return Vec(x + rhs.x, y + rhs.y);
+        }
+
+        Vec& operator+=(const Vec& rhs) {
+            x += rhs.x;
+            y += rhs.y;
             return *this;
         }
 
-        Vec<T, N> operator*(const T rhs) const {
-            std::array<T, N> new_data = m_data;
-            for (auto&& elem : new_data) {
-                elem *= rhs;
-            }
-            return Vec<T, N>(new_data);
+        Vec operator*(const float rhs) const {
+            return Vec(x * rhs, y * rhs);
         }
 
-        Vec<T, N>& operator*=(const T rhs) {
-            for (auto&& elem : m_data) {
-                elem *= rhs;
-            }
+        Vec& operator*=(const float rhs) {
+            x *= rhs;
+            y *= rhs;
             return *this;
         }
 
-        T norm_sqr() const {
-            T total = 0.f;
-            for (auto elem : m_data) {
-                total += elem*elem;
-            }
-            return total;
+        Vec normalized() const {
+            return *this * (1.f/std::sqrt(norm_sqr()));
         }
 
-        T dot(const Vec<T, N>& rhs) {
-            T total = 0.f;
-            for (size_t i = 0; i < N; ++i) {
-                total += m_data[i] + rhs.m_data[i];
-            }
-            return total;
+        float norm() const {
+            return std::sqrt(x*x + y*y);
         }
 
-    private:
-        void _construct(const size_t i, T x) {
-            m_data[i] = x;
+        float norm_sqr() const {
+            return x*x + y*y;
         }
 
-        template<typename... Args>
-        void _construct(const size_t i, T x, Args... args) {
-            m_data[i] = x;
-            _construct(i+1, args...);
+        float dot(const Vec& rhs) {
+            return x*rhs.x + y*rhs.y;
         }
 
-        std::array<T, N> m_data;
+        float x;
+        float y;
 };
 
-typedef Vec<float, 2> Vec2f;
-typedef Vec<float, 3> Vec3f;
-
 void py_init_vec(py::module& m) {
-    py::class_<Vec2f>(m, "Vec2f")
+    py::class_<Vec>(m, "Vec")
         .def(py::init<>())
-        .def(py::init<const std::array<float, 2>&&>());
-
-    py::class_<Vec3f>(m, "Vec3f")
-        .def(py::init<>())
-        .def(py::init<const std::array<float, 3>&&>());
+        .def(py::init<const float, const float>());
 }
 
 #endif /* __VEC_HPP__ */

--- a/src/Wall.hpp
+++ b/src/Wall.hpp
@@ -13,24 +13,28 @@ namespace py = pybind11;
 class Wall {
     public:
         Wall() {
-            m_vertices = std::vector<Vec2f>();
+            m_vertices = std::vector<Vec>();
         }
-        Wall(const std::vector<Vec2f>& vertices) {
+        Wall(const std::vector<Vec>& vertices) {
             m_vertices = vertices;
         }
 
-        void add_vertex(const Vec2f& vertex) {
+        void add_vertex(const Vec& vertex) {
             m_vertices.push_back(vertex);
         }
 
+        std::vector<Vec>& get_vertices() {
+            return m_vertices;
+        }
+
     private:
-        std::vector<Vec2f> m_vertices;
+        std::vector<Vec> m_vertices;
 };
 
 void py_init_wall(py::module& m) {
     py::class_<Wall>(m, "Wall")
         .def(py::init<>())
-        .def(py::init<std::vector<Vec2f>&>())
+        .def(py::init<std::vector<Vec>&>())
         .def("add_vertex", &Wall::add_vertex);
 }
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,17 +1,33 @@
-from simulator import Vec2f, Particle2f, Wall, Simulator
+from simulator import Vec, Particle, Wall, Simulator
 import random
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
-sim = Simulator(30)
+wall_vertices = [[(-2.0, -2.0), (2.0, -2.0), (2.0, 2.0), (-2.0, 2.0), (-2.0, -2.0)], 
+                 [(1.0, 1.8), (1.8, 0.0), (1.0, -1.8)]]
+
+walls = [Wall([Vec(v[0], v[1]) for v in w]) for w in wall_vertices]
+
+sim = Simulator(30, walls)
 
 fig, ax = plt.subplots()
 scatter, = plt.plot([], [], 'o')
 
+for w in wall_vertices:
+    xs = [v[0] for v in w]
+    ys = [v[1] for v in w]
+    plt.plot(xs, ys, '-k')
+
+for w in wall_vertices:
+    xs = [v[0] for v in w]
+    ys = [v[1] for v in w]
+    plt.plot(xs, ys, '-k')
+
 def anim_init():
-    ax.set_xlim(-2, 2)
-    ax.set_ylim(-2, 2)
-    return scatter,
+    ax.set_xlim(-2.2, 2.2)
+    ax.set_ylim(-2.2, 2.2)
+
+    return [scatter]
 
 def anim_update(_frame):
     sim.step(0.001)
@@ -26,8 +42,9 @@ def anim_update(_frame):
     sim.free_allocation()
 
     scatter.set_data(xs, ys)
-    return scatter,
+    return [scatter]
 
-anim = FuncAnimation(fig, anim_update, init_func=anim_init, blit=True, interval=10, frames=400)
-anim.save('/Users/pvirally/Desktop/gif.gif', writer='imagemagick', fps=60)
-#  plt.show()
+anim = FuncAnimation(fig, anim_update, init_func=anim_init, blit=True, interval=10)
+plt.show()
+#  anim = FuncAnimation(fig, anim_update, init_func=anim_init, blit=True, interval=10, frames=400)
+#  anim.save('/Users/pvirally/Desktop/gif.gif', writer='imagemagick', fps=60)


### PR DESCRIPTION
The `Vec` class in `src/Vec.hpp` has been simplified (for code readability, not for performance as the perfomance is identical).

The `Particle` class' `Particle::step(float dt)` function now uses velocity [Velocity Verlet](https://www.wikiwand.com/en/Verlet_integration#/Velocity_Verlet) because it is a symplectic integrator.

I have also ~~removed~~commented out the particle-particle interaction because I believe we are in the ideal gas regime. If I am wrong, it is quite easy to undo this change.